### PR TITLE
Make some code suggestions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,9 @@ fn classify_reads(
                     }
                     Entry::Vacant(_) => psc.num_inconsistent_reads += 1,
                 }
-                psc.frac_consistent = psc.num_consistent_reads as f32
-                    / (psc.num_consistent_reads + psc.num_inconsistent_reads) as f32
             }
+            psc.frac_consistent = psc.num_consistent_reads as f32
+                / (psc.num_consistent_reads + psc.num_inconsistent_reads) as f32
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,11 +46,6 @@ struct PrimerSet {
     frac_consistent: f32,
 }
 
-// struct KmerInfo {
-//     kmer: Kmer16,
-//     primer_seq: DnaString
-// }
-
 const EXPECTED_NON_MATCHING_RATIO: f32 = 0.005;
 const DEFAULT_PRIMER_SET: &str = "unknown";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,7 @@ fn identify_primer_set(primer_set_counters: &[PrimerSet]) -> (String, f32) {
 
     //TODO: check that ratio of left and right are similar for each primer pair
 
-    let mut ps_fracs: Vec<(String, f32)> = Vec::new();
-    for psc in primer_set_counters {
+    let mut ps_fracs = primer_set_counters.iter().map(|psc| {
         log::debug!(
             "{} consistent reads: {:?}",
             psc.name,
@@ -265,8 +264,8 @@ fn identify_primer_set(primer_set_counters: &[PrimerSet]) -> (String, f32) {
             psc.num_consistent_reads,
             psc.num_inconsistent_reads
         );
-        ps_fracs.push((String::from(&psc.name), psc.frac_consistent));
-    }
+        (String::from(&psc.name), psc.frac_consistent)
+    }).collect::<Vec<(String, f32)>>();
     //TODO add a bootstrapping confidence calculation
     ps_fracs.sort_unstable_by_key(|ps_frac| (ps_frac.1 * -1000.0) as i32);
     log::debug!("matching fractions: {:?}", ps_fracs);


### PR DESCRIPTION
This PR doesn't change the functionality of the code but rather makes some suggestions in line with Rust idioms. The biggest change is in `populate_primer_count_hash` where `let key = if` replaces the double-assignment of `key` and `is_some` is used at the insert step and then the rewrite of `import_primer_sets` to reduce use of `mut` and prefer a more "functional" style to a more "C-like" approach of initialising and then updating a hashmap.

Further down the code `identify_primer_sets` has an if-chain replaced with a `match` based on a clippy suggestion. I'm less sure that this is an improvement - it uses `match` rather than an if-chain, which is more ideomatic for Rust, but the use of `Ordering::Equal` etc might make things less readable to some users.

